### PR TITLE
add godep support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -81,7 +81,13 @@ GoRun.prototype._spawn = function() {
   var args = Array.prototype.slice.call(arguments);
   log("starting process...");
 
-  return spawn("go", args, this.opts);
+  if (this.opts.godep) {
+    log("using `godep go`");
+    args.unshift("go");
+    return spawn("godep", args, this.opts);
+  } else {
+    return spawn("go", args, this.opts);
+  }
 };
 
 var noop = function() {
@@ -172,4 +178,3 @@ GoRun.prototype.restart = function() {
     self.run();
   });
 };
-


### PR DESCRIPTION
If you're using godep, you need to use `godep go run` instead of `go run`.  This adds a flag to the opts that enable using godep instead of go.  
