### PR TITLE
use tree-kill instead of pstree to simplify code and support windows

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,11 @@
     var go;
 
     gulp.task("go-run", function() {
-      go = gulpgo.run("main.go", ["--arg1", "value1"], {cwd: __dirname, stdio: 'inherit'});
+      go = gulpgo.run("main.go", ["--arg1", "value1"], {
+	    cwd: __dirname,
+	    onStdout: function(buffer) { console.log(buffer.toString('utf8')); },
+	    onStderr:  function(buffer) { console.error(buffer.toString('utf8')); }
+	  });
     });
 
     gulp.task("devs", ["go-run"], function() {

--- a/index.js
+++ b/index.js
@@ -125,7 +125,8 @@ GoRun.prototype._stop = function(callback) {
   var pid = this.proc.pid;
   treeKill(pid, 'SIGKILL', function(err) {
     if(err) {
-      console.log(err);
+      log(err);
+	  callback();
     } else {
       log("["+pid+"]", "process stopped");
       callback();

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var pstree = require("ps-tree");
+var treeKill = require("tree-kill");
 var spawn  = require("child_process").spawn;
 var exec   = require("child_process").exec;
 
@@ -123,32 +123,11 @@ GoRun.prototype._stop = function(callback) {
   }
 
   var pid = this.proc.pid;
-  pstree(pid, function (err, children) {
-    var i = 0;
-    var len = children.length;
-
-    var kill = function(n) {
-      var child = children[n];
-      if (!!!child) {
-        callback();
-        return;
-      }
-
-      exec("kill " + child.PID, function() {
-        i++;
-        if (i === len) {
-          log("["+pid+"]", "process stopped");
-
-          callback();
-          return;
-        }
-
-        kill(i);
-      });
-    };
-
-    kill(i);
+  treeKill(1, 'SIGKILL', function(err) {
+    log("["+pid+"]", "process stopped");
+    callback();
   });
+
 };
 
 GoRun.prototype.stop = function(callback) {

--- a/index.js
+++ b/index.js
@@ -123,9 +123,13 @@ GoRun.prototype._stop = function(callback) {
   }
 
   var pid = this.proc.pid;
-  treeKill(1, 'SIGKILL', function(err) {
-    log("["+pid+"]", "process stopped");
-    callback();
+  treeKill(pid, 'SIGKILL', function(err) {
+    if(err) {
+      console.log(err);
+    } else {
+      log("["+pid+"]", "process stopped");
+      callback();
+    }
   });
 
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
-    "ps-tree": "0.0.3"
+    "tree-kill": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,10 @@
   },
   "dependencies": {
     "tree-kill": "^1.1.0"
+  },
+  "jspm": {
+    "dependencies": {
+      "tree-kill": "npm:tree-kill@^1.1.0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,5 @@
   },
   "dependencies": {
     "tree-kill": "^1.1.0"
-  },
-  "jspm": {
-    "dependencies": {
-      "tree-kill": "npm:tree-kill@^1.1.0"
-    }
   }
 }


### PR DESCRIPTION
I have only tested this on windows, but it works while it did not before. Do with this what you will. 
